### PR TITLE
fix PHP fatal errors in programmatically generated form sample

### DIFF
--- a/typo3/sysext/form/Documentation/D/FrontendRendering/Index.rst
+++ b/typo3/sysext/form/Documentation/D/FrontendRendering/Index.rst
@@ -213,6 +213,7 @@ Implement a ``FormFactory`` and build the form::
    declare(strict_types = 1);
    namespace VENDOR\MySitePackage\Domain\Factory;
 
+   use Psr\Http\Message\ServerRequestInterface;
    use TYPO3\CMS\Core\Utility\GeneralUtility;
    use TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator;
    use TYPO3\CMS\Extbase\Validation\Validator\StringLengthValidator;
@@ -232,7 +233,11 @@ Implement a ``FormFactory`` and build the form::
         * @param string $prototypeName
         * @return FormDefinition
         */
-       public function build(array $configuration, string $prototypeName = null): FormDefinition
+       public function build(
+            array $configuration,
+            string $prototypeName = null,
+            ServerRequestInterface|null $request = null
+        ): FormDefinition
        {
            $prototypeName = 'standard';
            $configurationService = GeneralUtility::makeInstance(ConfigurationService::class);
@@ -269,6 +274,14 @@ Implement a ``FormFactory`` and build the form::
            return $form;
        }
    }
+
+Add this to your Configuration/Services.yaml
+
+.. code-block:: yaml
+
+  VENDOR\MySitePackage\Domain\Factory\CustomFormFactory:
+    public: true
+
 
 Use this form within your fluid template.
 


### PR DESCRIPTION
Change in signature of build() fixes:
PHP Fatal error:  Declaration of Taketool\Classifieds\Domain\Factory\TestFormFactory::build(array $configuration, ?string $prototypeName = null): TYPO3\CMS\Form\Domain\Model\FormDefinition must be compatible with TYPO3\CMS\Form\Domain\Factory\FormFactoryInterface::build(array $configuration, ?string $prototypeName = null, ?Psr\Http\Message\ServerRequestInterface $request = null): TYPO3\CMS\Form\Domain\Model\FormDefinition in /var/www/html/packages/classifieds/Classes/Domain/Factory/TestFormFactory.php on line 26

Adding FormFactory to Services.yaml fixes:
PHP Fatal error:  During inheritance of Taketool\Classifieds\Domain\Factory\TestFormFactory, while autoloading Taketool\Classifieds\Domain\Factory\ServerRequestInterface: Uncaught ReflectionException: Class "Taketool\Classifieds\Domain\Factory\ServerRequestInterface" not found while loading "Taketool\Classifieds\Domain\Factory\TestFormFactory". in /var/www/html/vendor/composer/ClassLoader.php:576